### PR TITLE
feat: smooth image transition, reduce image size

### DIFF
--- a/web/src/components/Image.svelte
+++ b/web/src/components/Image.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { fade } from "svelte/transition";
+
+  export let src: string;
+  export let alt: string;
+  export let srcset: string;
+  let loaded = false;
+
+  const onload = () => {
+    loaded = true
+  };
+</script>
+
+{#if loaded}
+  <img {src} {srcset} {alt} transition:fade />
+{:else}
+  <img aria-hidden class="temp_img" {src} {srcset} {alt} on:load={onload} />
+{/if}
+
+<style>
+  .temp_img {
+    visibility: hidden;
+  }
+</style>

--- a/web/src/routes/poems/[slug].svelte
+++ b/web/src/routes/poems/[slug].svelte
@@ -28,6 +28,7 @@
 	import SvelteSeo from 'svelte-seo'
 	import { fade } from 'svelte/transition'
 	import blocksToHtml from '@sanity/block-content-to-html'
+	import FadeImage from '../../components/Image.svelte'
 
 	type Slug = {
 		_type: string,
@@ -61,7 +62,7 @@
     },
     images: [
       {
-        url: poemImage ? urlFor(poemImage).url() : '',
+        url: poemImage ? urlFor(poemImage).size(650, 650).url() : '',
         width: 650,
         height: 650,
         alt: poemImage ? poemImage.alt : '',
@@ -75,9 +76,15 @@
 	<article>
 		<h1 class="poem-title" transition:fade>{ name }</h1>
 		{#if poemImage}
-			<div id="image">
+			<div id="image" class="image-container">
 				{#if poemImage.alt}
-					<img alt="{poemImage.alt}" src="{ urlFor(poemImage).url() }" transition:fade>
+					{#key poem.slug.current}
+						<FadeImage 
+							alt="{poemImage.alt}"
+							srcset="{urlFor(poemImage).size(200, 200).url()}, {urlFor(poemImage).size(400, 400).url()} 2x"
+							src="{ urlFor(poemImage).size(400, 400).url() }"
+						/>
+					{/key}
 				{/if}
 			</div>
 		{/if}
@@ -101,11 +108,18 @@
 </section>
 
 <style>
-	img {
-		border-radius: 100px;
+	.image-container {
+		position: relative;
 		width: 200px;
 		height: 200px;
-		background-size: cover;
+	}
+
+	.image-container :global(img) {
+		position: absolute;
+		border-radius: 100px;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
 	}
 
 	.end-mark {


### PR DESCRIPTION
Hey @andypbrowne, this PR ensures the image for each poem are loaded at the correct size, saving loading time + bandwidth.

I've also added a fix that smoothen the image transition between poems:
![Screen Recording 2021-11-11 at 4 21 56 PM](https://user-images.githubusercontent.com/3383539/141257728-45e63510-b5cb-4cc2-8468-489d2788453d.gif)

First, the images are keyed & absolutely positioned (so they stacked on top of eachother) to create the crossfade effect. Then, inside a <Image /> component, I use a temporary img to preload the image. Once the image is loaded, the temporary img is replaced with the real one, with transition enabled.

It's a little hackish, but allow us to use svelte's transition, avoid manual image loading logic i.e which size, srcset, etc. or having to involve svelte internal to delay the transition.

Let me know what you think!